### PR TITLE
relax install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,10 @@ setup(
     author_email='Sertalp.Cay@sas.com',
     license='Apache v2.0',
     install_requires=[
-        'pandas == 1.1.0',
+        'pandas',
         'swat == 1.6.1',
-        'saspy == 3.3.7',
-        'numpy == 1.15.4'
+        'saspy',
+        'numpy'
         ],
     setup_requires=[
         'numpy'


### PR DESCRIPTION
sasoptpy has hard coded requirements for pandas, saspy, and numpy in the `setup.py` I ran the 242 active tests (`python -m unittest discover -s tests/ -p 'test*.py'`) and got the exact same results with the strictly specified versions as when the versions could float to the most recently released.

The test were run in two separate docker (repo2docker) containers.


When I removed the swat strict version I got 13 tests failures so that will need further investigation.